### PR TITLE
libcrystal: fix wrong copy size from String#split

### DIFF
--- a/userspace/libraries/libc/src/functions/malloc.cr
+++ b/userspace/libraries/libc/src/functions/malloc.cr
@@ -203,6 +203,7 @@ module Malloc
   private def footer_for_block(hdr)
     ftr = Pointer(Data::Footer).new(hdr.address + sizeof(Data::Header) + hdr.value.size)
     if ftr.value.magic != FOOTER_MAGIC
+      Stdio.stderr.fputs "free: invalid magic number for ftr"
       abort
     end
     ftr

--- a/userspace/libraries/libcrystal/core/string.cr
+++ b/userspace/libraries/libcrystal/core/string.cr
@@ -167,7 +167,7 @@ class String
 
         if !remove_empty || (remove_empty && bytesize != 0)
           str = (String.new(bytesize) { |buffer|
-            byte_slice[last_sep_byte_idx, bytesize].copy_to buffer, unisize
+            byte_slice[last_sep_byte_idx, bytesize].copy_to buffer, bytesize
             { bytesize, unisize }
           }).not_nil!
           yield str
@@ -196,7 +196,7 @@ class String
 
     if !remove_empty || (remove_empty && bytesize != 0)
       str = (String.new(bytesize + 1) { |buffer|
-        byte_slice[last_sep_byte_idx, bytesize].copy_to buffer, unisize
+        byte_slice[last_sep_byte_idx, bytesize].copy_to buffer, bytesize
         { bytesize, unisize }
       }).not_nil!
       yield str


### PR DESCRIPTION
- libc: abort malloc() if footer has wrong magic number